### PR TITLE
update tests for multiple file test

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,8 +49,8 @@ module.exports = function(grunt) {
         options: {
         },
         files: {
-          'tmp/default.png': ['test/fixtures/sequence.uml'],
-          'tmp/default-napkin.png': ['test/fixtures/sequence.uml'],
+          'tmp/multiple-one.png': ['test/fixtures/sequence.uml'],
+          'tmp/multiple-two.png': ['test/fixtures/sequence.uml'],
         },
       },
       outputType_svg_options: {

--- a/test/websequencediagrams_test.js
+++ b/test/websequencediagrams_test.js
@@ -45,6 +45,19 @@ exports.websequencediagrams = {
 
     test.done();
   },
+  multiple_files: function(test) {
+    test.expect(2);
+
+    var actual = grunt.file.read('tmp/multiple-one.png');
+    var expected = grunt.file.read('test/expected/default.png');
+    test.equal(actual, expected, 'should generate first diagram.');
+
+    actual = grunt.file.read('tmp/multiple-two.png');
+    expected = grunt.file.read('test/expected/default.png');
+    test.equal(actual, expected, 'should generate second diagram.');
+
+    test.done();
+  },
   outputType_svg_options: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
When I forked this and ran the tests they failed. In looking into the failure; the execution of the multiple files would overwrite the original `default.png` and `default-napkin.png` files. This only really caused a problem since in the multiple case it's using the default style and therefore conflicting when the test that the `default-napkin.png` is rendered in napkin style. I've modified this to use different outputs for the multiple execution case.

Note: I'm seeing odd behavior today where the images appear to be the same but the binary file comparison is failing. I don't see anything obvious; but you may want to double-check that I haven't done something wrong in making this change.

Changes:

* use a different file output when running multiple tests
* add an additional test assertion for the multiple file test